### PR TITLE
Add -o to force unzip intellij settings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,5 +8,5 @@ scripts/intellij.sh
 
 echo "Importing IDE settings..."
 mkdir -p ~/.config/JetBrains/RemoteDev-IU/_home_owner_src_credit_card/
-# unzip settings.zip -d ~/.config/JetBrains/RemoteDev-IU/_home_owner_src_credit_card/
+unzip -o settings.zip -d ~/.config/JetBrains/RemoteDev-IU/_home_owner_src_credit_card/
 


### PR DESCRIPTION
Since now we have pre-warm for intellij, that folder will already exist when install.sh runs